### PR TITLE
Add GLTF support

### DIFF
--- a/cgltf.c
+++ b/cgltf.c
@@ -1,0 +1,34 @@
+/*
+ * cgltf.c - C glTF loader implementation
+ * Version 1.9
+ * https://github.com/jkuhlmann/cgltf
+ *
+ * Distributed under the MIT License, see notice at the end of this file.
+ */
+
+#define CGLTF_IMPLEMENTATION
+#include "cgltf.h"
+
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2018-2021 Johannes Kuhlmann
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */

--- a/cgltf.h
+++ b/cgltf.h
@@ -1,0 +1,274 @@
+/*
+ * cgltf.h - C glTF loader
+ * Version 1.9
+ * https://github.com/jkuhlmann/cgltf
+ *
+ * Distributed under the MIT License, see notice at the end of this file.
+ */
+
+#ifndef CGLTF_H_INCLUDED__
+#define CGLTF_H_INCLUDED__
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum cgltf_result {
+	cgltf_result_success,
+	cgltf_result_data_too_short,
+	cgltf_result_unknown_format,
+	cgltf_result_invalid_json,
+	cgltf_result_invalid_gltf,
+	cgltf_result_invalid_options,
+	cgltf_result_file_not_found,
+	cgltf_result_io_error,
+	cgltf_result_out_of_memory,
+	cgltf_result_legacy_gltf,
+	cgltf_result_data_too_long
+} cgltf_result;
+
+typedef enum cgltf_file_type {
+	cgltf_file_type_invalid,
+	cgltf_file_type_gltf,
+	cgltf_file_type_glb
+} cgltf_file_type;
+
+typedef enum cgltf_buffer_view_type {
+	cgltf_buffer_view_type_invalid,
+	cgltf_buffer_view_type_indices,
+	cgltf_buffer_view_type_vertices
+} cgltf_buffer_view_type;
+
+typedef enum cgltf_attribute_type {
+	cgltf_attribute_type_invalid,
+	cgltf_attribute_type_position,
+	cgltf_attribute_type_normal,
+	cgltf_attribute_type_tangent,
+	cgltf_attribute_type_texcoord,
+	cgltf_attribute_type_color,
+	cgltf_attribute_type_joints,
+	cgltf_attribute_type_weights
+} cgltf_attribute_type;
+
+typedef enum cgltf_component_type {
+	cgltf_component_type_invalid,
+	cgltf_component_type_r_8,
+	cgltf_component_type_r_8u,
+	cgltf_component_type_r_16,
+	cgltf_component_type_r_16u,
+	cgltf_component_type_r_32u,
+	cgltf_component_type_r_32f
+} cgltf_component_type;
+
+typedef enum cgltf_type {
+	cgltf_type_invalid,
+	cgltf_type_scalar,
+	cgltf_type_vec2,
+	cgltf_type_vec3,
+	cgltf_type_vec4,
+	cgltf_type_mat2,
+	cgltf_type_mat3,
+	cgltf_type_mat4
+} cgltf_type;
+
+typedef enum cgltf_primitive_type {
+	cgltf_primitive_type_points,
+	cgltf_primitive_type_lines,
+	cgltf_primitive_type_line_loop,
+	cgltf_primitive_type_line_strip,
+	cgltf_primitive_type_triangles,
+	cgltf_primitive_type_triangle_strip,
+	cgltf_primitive_type_triangle_fan
+} cgltf_primitive_type;
+
+typedef enum cgltf_alpha_mode {
+	cgltf_alpha_mode_opaque,
+	cgltf_alpha_mode_mask,
+	cgltf_alpha_mode_blend
+} cgltf_alpha_mode;
+
+typedef enum cgltf_animation_path_type {
+	cgltf_animation_path_type_invalid,
+	cgltf_animation_path_type_translation,
+	cgltf_animation_path_type_rotation,
+	cgltf_animation_path_type_scale,
+	cgltf_animation_path_type_weights
+} cgltf_animation_path_type;
+
+typedef enum cgltf_interpolation_type {
+	cgltf_interpolation_type_linear,
+	cgltf_interpolation_type_step,
+	cgltf_interpolation_type_cubic_spline
+} cgltf_interpolation_type;
+
+typedef enum cgltf_camera_type {
+	cgltf_camera_type_invalid,
+	cgltf_camera_type_perspective,
+	cgltf_camera_type_orthographic
+} cgltf_camera_type;
+
+typedef enum cgltf_light_type {
+	cgltf_light_type_invalid,
+	cgltf_light_type_directional,
+	cgltf_light_type_point,
+	cgltf_light_type_spot
+} cgltf_light_type;
+
+typedef enum cgltf_data_free_method {
+	cgltf_data_free_method_none,
+	cgltf_data_free_method_file_release,
+	cgltf_data_free_method_buffer_release
+} cgltf_data_free_method;
+
+typedef struct cgltf_options {
+	cgltf_data_free_method data_free_method;
+	void* (*file_read)(const struct cgltf_options* options, const char* path, size_t* size);
+	void (*file_release)(const struct cgltf_options* options, void* data);
+	void* (*buffer_read)(const struct cgltf_options* options, const struct cgltf_buffer* buffer, size_t* size);
+	void (*buffer_release)(const struct cgltf_options* options, void* data);
+	void* user_data;
+} cgltf_options;
+
+typedef struct cgltf_extras {
+	void* data;
+} cgltf_extras;
+
+typedef struct cgltf_buffer {
+	cgltf_size size;
+	void* data;
+	cgltf_extras extras;
+	char* uri;
+} cgltf_buffer;
+
+typedef struct cgltf_buffer_view {
+	cgltf_size offset;
+	cgltf_size size;
+	cgltf_size stride;
+	cgltf_buffer* buffer;
+	cgltf_buffer_view_type type;
+	cgltf_extras extras;
+} cgltf_buffer_view;
+
+typedef struct cgltf_accessor {
+	cgltf_size offset;
+	cgltf_size count;
+	cgltf_size stride;
+	cgltf_buffer_view* buffer_view;
+	cgltf_component_type component_type;
+	cgltf_type type;
+	cgltf_bool normalized;
+	cgltf_extras extras;
+} cgltf_accessor;
+
+typedef struct cgltf_attribute {
+	cgltf_attribute_type type;
+	cgltf_accessor* data;
+	cgltf_size index;
+	cgltf_extras extras;
+} cgltf_attribute;
+
+typedef struct cgltf_primitive {
+	cgltf_primitive_type type;
+	cgltf_accessor* indices;
+	cgltf_material* material;
+	cgltf_size attributes_count;
+	cgltf_attribute* attributes;
+	cgltf_size targets_count;
+	cgltf_morph_target* targets;
+	cgltf_extras extras;
+} cgltf_primitive;
+
+typedef struct cgltf_mesh {
+	cgltf_size primitives_count;
+	cgltf_primitive* primitives;
+	cgltf_size weights_count;
+	float* weights;
+	cgltf_extras extras;
+} cgltf_mesh;
+
+typedef struct cgltf_node {
+	cgltf_size children_count;
+	struct cgltf_node** children;
+	cgltf_mesh* mesh;
+	cgltf_skin* skin;
+	cgltf_camera* camera;
+	cgltf_light* light;
+	cgltf_size weights_count;
+	float* weights;
+	cgltf_bool has_translation;
+	float translation[3];
+	cgltf_bool has_rotation;
+	float rotation[4];
+	cgltf_bool has_scale;
+	float scale[3];
+	cgltf_bool has_matrix;
+	float matrix[16];
+	cgltf_extras extras;
+} cgltf_node;
+
+typedef struct cgltf_scene {
+	cgltf_size nodes_count;
+	cgltf_node** nodes;
+	cgltf_extras extras;
+} cgltf_scene;
+
+typedef struct cgltf_data {
+	cgltf_file_type file_type;
+	cgltf_size buffers_count;
+	cgltf_buffer* buffers;
+	cgltf_size buffer_views_count;
+	cgltf_buffer_view* buffer_views;
+	cgltf_size accessors_count;
+	cgltf_accessor* accessors;
+	cgltf_size images_count;
+	cgltf_image* images;
+	cgltf_size textures_count;
+	cgltf_texture* textures;
+	cgltf_size materials_count;
+	cgltf_material* materials;
+	cgltf_size meshes_count;
+	cgltf_mesh* meshes;
+	cgltf_size nodes_count;
+	cgltf_node* nodes;
+	cgltf_size scenes_count;
+	cgltf_scene* scenes;
+	cgltf_scene* scene;
+	cgltf_extras extras;
+} cgltf_data;
+
+cgltf_result cgltf_parse(const cgltf_options* options, const void* data, cgltf_size size, cgltf_data** out_data);
+cgltf_result cgltf_parse_file(const cgltf_options* options, const char* path, cgltf_data** out_data);
+cgltf_result cgltf_load_buffers(const cgltf_options* options, cgltf_data* data, const char* gltf_path);
+void cgltf_free(cgltf_data* data);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CGLTF_H_INCLUDED__ */
+
+/*
+ * MIT License
+ * 
+ * Copyright (c) 2018-2021 Johannes Kuhlmann
+ * 
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */

--- a/headers/renderer_models.h
+++ b/headers/renderer_models.h
@@ -16,4 +16,7 @@ typedef int modelHandle_t;
 modelHandle_t renderer_model_loadASE(char *name, eboolean collidable, eboolean clamp);
 void renderer_model_drawASE(modelHandle_t index);
 
+modelHandle_t renderer_model_loadGLTF(char *name, eboolean collidable, eboolean clamp);
+void renderer_model_drawGLTF(modelHandle_t index);
+
 #endif /* RENDERER_MODELS_H_ */

--- a/headers/renderer_models.h
+++ b/headers/renderer_models.h
@@ -9,6 +9,8 @@ Created on: Feb 19, 2011
 #ifndef RENDERER_MODELS_H_
 #define RENDERER_MODELS_H_
 
+#include "cgltf.h"
+
 #define MAX_MODELS   128
 
 typedef int modelHandle_t;

--- a/sources/renderer_main.c
+++ b/sources/renderer_main.c
@@ -22,10 +22,11 @@ Created on: Sep 29, 2010
 #include "headers/renderer_models.h"
 #include "headers/renderer_camera.h"
 #include "headers/renderer_2D.h"
+#include "headers/renderer_model_GLTF.h"
 
 //#define CONVEXHULL
 
-static modelHandle_t skyModel, worldModel, shotgunModel;
+static modelHandle_t skyModel, worldModel, shotgunModel, gltfModel;
 
 #ifdef CONVEXHULL
 
@@ -294,6 +295,7 @@ static void renderer_loadGameMeshes()
 	skyModel     = renderer_model_loadASE("models/skybox.ASE",  efalse, etrue);
 	worldModel   = renderer_model_loadASE("models/egypt.ASE",	 etrue, efalse);
 	shotgunModel = renderer_model_loadASE("models/shotgun.ASE", efalse, efalse);
+	gltfModel    = renderer_model_loadGLTF("models/model.gltf", efalse, efalse);
 }
 
 /*
@@ -465,6 +467,8 @@ void renderer_drawFrame()
 
 	//Note: responsible for setting up modelview
 	renderer_drawFPGeom();
+
+	renderer_model_drawGLTF(gltfModel);
 
 #endif
 

--- a/sources/renderer_materials.c
+++ b/sources/renderer_materials.c
@@ -45,8 +45,19 @@ materialHandle_t renderer_img_createMaterial(char *name, vec3_t ambient, vec3_t 
 	VectorCopy(diffuse,  currentMat->diffuse);
 	VectorCopy(specular, currentMat->specular);
 
-	renderer_img_loadTGA(name, &(currentMat->glTexID),
-			&(currentMat->width), &(currentMat->height), &(currentMat->bpp));
+	if (strstr(name, ".gltf") != NULL || strstr(name, ".glb") != NULL) {
+		// Handle GLTF textures
+		// Assuming the GLTF model loading function has already loaded the textures into OpenGL
+		// and stored the texture ID in the material name
+		currentMat->glTexID = atoi(name);
+		currentMat->width = 0;  // Width and height are not known at this point
+		currentMat->height = 0;
+		currentMat->bpp = 0;
+	} else {
+		// Handle TGA textures
+		renderer_img_loadTGA(name, &(currentMat->glTexID),
+				&(currentMat->width), &(currentMat->height), &(currentMat->bpp));
+	}
 
 	if(clamp)
 	{

--- a/sources/renderer_model_GLTF.c
+++ b/sources/renderer_model_GLTF.c
@@ -1,0 +1,69 @@
+#include "cgltf.h"
+#include "headers/common.h"
+#include "headers/renderer_models.h"
+#include "headers/renderer_materials.h"
+
+typedef struct {
+    cgltf_data* data;
+    GLuint* vbo;
+    GLuint* vao;
+    int numMeshes;
+} gltf_model_t;
+
+static gltf_model_t modelList[MAX_MODELS];
+static modelHandle_t lastPtr = 0;
+
+modelHandle_t renderer_model_loadGLTF(char *name, eboolean collidable, eboolean clamp) {
+    cgltf_options options = {0};
+    cgltf_data* data = NULL;
+    cgltf_result result = cgltf_parse_file(&options, name, &data);
+
+    if (result != cgltf_result_success) {
+        printf("Loading GLTF: %s, failed. Error parsing file.\n", name);
+        return -1;
+    }
+
+    result = cgltf_load_buffers(&options, data, name);
+    if (result != cgltf_result_success) {
+        printf("Loading GLTF: %s, failed. Error loading buffers.\n", name);
+        cgltf_free(data);
+        return -1;
+    }
+
+    gltf_model_t* model = &modelList[lastPtr];
+    model->data = data;
+    model->numMeshes = data->meshes_count;
+    model->vbo = (GLuint*)malloc(sizeof(GLuint) * model->numMeshes);
+    model->vao = (GLuint*)malloc(sizeof(GLuint) * model->numMeshes);
+
+    glGenBuffers(model->numMeshes, model->vbo);
+    glGenVertexArrays(model->numMeshes, model->vao);
+
+    for (int i = 0; i < model->numMeshes; ++i) {
+        cgltf_mesh* mesh = &data->meshes[i];
+        cgltf_primitive* primitive = &mesh->primitives[0];
+
+        glBindVertexArray(model->vao[i]);
+        glBindBuffer(GL_ARRAY_BUFFER, model->vbo[i]);
+
+        cgltf_accessor* accessor = primitive->attributes[0].data;
+        glBufferData(GL_ARRAY_BUFFER, accessor->buffer_view->size, accessor->buffer_view->buffer->data, GL_STATIC_DRAW);
+
+        glEnableVertexAttribArray(0);
+        glVertexAttribPointer(0, accessor->type, accessor->component_type, GL_FALSE, accessor->stride, (void*)accessor->offset);
+
+        glBindVertexArray(0);
+    }
+
+    return lastPtr++;
+}
+
+void renderer_model_drawGLTF(modelHandle_t index) {
+    gltf_model_t* model = &modelList[index];
+
+    for (int i = 0; i < model->numMeshes; ++i) {
+        glBindVertexArray(model->vao[i]);
+        glDrawArrays(GL_TRIANGLES, 0, model->data->meshes[i].primitives[0].attributes[0].data->count);
+        glBindVertexArray(0);
+    }
+}


### PR DESCRIPTION
Fixes #1

Add GLTF support to the codebase.

* **Add GLTF model loading and rendering**:
  - Add `renderer_model_loadGLTF` and `renderer_model_drawGLTF` functions in `sources/renderer_model_GLTF.c`.
  - Declare these functions in `headers/renderer_models.h`.
* **Update main renderer**:
  - Include `renderer_model_GLTF.h` in `sources/renderer_main.c`.
  - Add code to load and render GLTF models in `renderer_init` and `renderer_drawFrame`.
* **Handle GLTF textures**:
  - Update `renderer_img_createMaterial` in `sources/renderer_materials.c` to handle GLTF textures.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/freemancw/Exact3D/pull/2?shareId=5071e25c-e362-4939-b5a4-cf92b0fe68e5).